### PR TITLE
Adding the propagation of software register initial values to the output

### DIFF
--- a/scripts/python/xml2vhdl-ox/xml2vhdl/template/xml2vhdl_slave.template.vhd
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/template/xml2vhdl_slave.template.vhd
@@ -130,6 +130,7 @@ begin
       end if;
       if <BUS_RST> = '<BUS_RST_VAL>' then
          <BUS_PREFIX_><SLAVE_NAME>_reset(<BUS_PREFIX_><SLAVE_NAME>_int<RESET_GENERICS_MAP>);
+         <BUS_PREFIX_><SLAVE_NAME>_out_we <= <BUS_PREFIX_><SLAVE_NAME>_reset_out_en(<BUS_PREFIX_><SLAVE_NAME>_int);        
       end if;
    end process;
    

--- a/scripts/python/xml2vhdl-ox/xml2vhdl/template/xml2vhdl_slave_pkg.template.vhd
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/template/xml2vhdl_slave_pkg.template.vhd
@@ -90,6 +90,7 @@ package <BUS_PREFIX_><SLAVE_NAME>_pkg is
    
    function <BUS_PREFIX_><SLAVE_NAME>_read_reg(signal <SLAVE_NAME>_decoded: in t_<BUS_PREFIX_><SLAVE_NAME>_decoded;
                                         signal <SLAVE_NAME>: t_<BUS_PREFIX_><SLAVE_NAME>) return std_logic_vector;
+   function <BUS_PREFIX_><SLAVE_NAME>_reset_out_en(signal <SLAVE_NAME>: t_<BUS_PREFIX_><SLAVE_NAME>) return t_<BUS_PREFIX_><SLAVE_NAME>_decoded;
 <REMOVE_IF_BLOCK_ONLY_END>
    
    function <BUS_PREFIX_><SLAVE_NAME>_demux(addr: std_logic_vector) return std_logic_vector;
@@ -124,10 +125,19 @@ package body <BUS_PREFIX_><SLAVE_NAME>_pkg is
 <REMOVE_IF_BLOCK_ONLY_START>
    procedure <BUS_PREFIX_><SLAVE_NAME>_reset(signal <SLAVE_NAME>: inout t_<BUS_PREFIX_><SLAVE_NAME><RESET_GENERICS_PROCEDURE>) is
    begin
-      
+
 <RESET_ASSIGN>
 
    end procedure;
+
+   function <BUS_PREFIX_><SLAVE_NAME>_reset_out_en(signal <SLAVE_NAME>: t_<BUS_PREFIX_><SLAVE_NAME>) return t_<BUS_PREFIX_><SLAVE_NAME>_decoded is
+       variable <SLAVE_NAME>_rst: t_<BUS_PREFIX_><SLAVE_NAME>_decoded;
+   begin
+
+<RESET_OUT_ENABLE>
+  
+     return <SLAVE_NAME>_rst;
+   end function;
    
    procedure <BUS_PREFIX_><SLAVE_NAME>_default_decoded(signal <SLAVE_NAME>: inout t_<BUS_PREFIX_><SLAVE_NAME>_decoded) is
    begin

--- a/scripts/python/xml2vhdl-ox/xml2vhdl/xml2slave.py
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/xml2slave.py
@@ -251,6 +251,23 @@ class Xml2Slave:
             records_decoded = re.sub(r"<<[0-9]*>>", "", records_decoded)
             records_decoded = re.sub(r"\|", "", records_decoded)
             records_decoded = re.sub(r"/", "", records_decoded)
+
+            #
+            # RESET OUT ENABLE
+            #
+            reset_out_enable = ""
+            snippet = ""
+            for node_id in slave.reverse_dict_key:
+                node_dict = slave.dict[node_id]
+                if node_dict['child_key']:
+                   if node_dict['complete_id'].find("*") == -1:
+                            for child in sorted(node_dict['child_key']):
+                                child_dict = slave.dict[str(child)]
+                                # if the child is a leaf, define it as base type (std_logic or std_logic_vector)
+                                if not child_dict['child_key']:
+                                    snippet += "\t\t" + node_dict['complete_id'] + "_rst." + child_dict['this_id'] + " := '1';\n"
+                            reset_out_enable += snippet
+
             #
             # REGISTER DESCRIPTOR RECORDS
             #
@@ -651,6 +668,7 @@ class Xml2Slave:
             vhdl_text = vhdl_text.replace("<SLAVE_NAME>", xml_mm.root.get('id'))
             vhdl_text = vhdl_text.replace("<RECORDS>\n", records)
             vhdl_text = vhdl_text.replace("<RECORDS_DECODED>\n", records_decoded)
+            vhdl_text = vhdl_text.replace("<RESET_OUT_ENABLE>\n", reset_out_enable)           
             vhdl_text = vhdl_text.replace("<DESCRIPTOR_RECORDS>\n", descr_records)
             vhdl_text = vhdl_text.replace("<DESCRIPTOR_RECORDS_INIT>\n", descr_records_init)
             vhdl_text = vhdl_text.replace("<RESET_GENERICS_PROCEDURE>", helper.string_io.indent(reset_generics_procedure, 0))


### PR DESCRIPTION
Made changes to xml2slave.py to generate a function that sets some record elements in the axi4lite_sys_block_pkg.vhd.
The function is called from axi4lite_sw_reg.vhd to set the axi4lite_sw_reg_out_we during a reset. Changes were made to
xml2vhdl_slave_pkg.template.vhd and xml2vhdl_slave.template.vhd to comply to the change in xml2slave.py.

The original problem was that software register intial values could not drive the blocks connected to the software register
output until an external write command (from casperfpga) is run.