### PR TITLE
numpy deprecated np.int alias

### DIFF
--- a/scripts/python/xml2vhdl-ox/xml2vhdl/helper/slave.py
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/helper/slave.py
@@ -401,7 +401,7 @@ class Slave:
         add_num = len(addresses)
         logger.info('Addresses are: {add_num}'
                     .format(add_num=add_num))
-        baddr = np.zeros((add_num, 32), dtype=np.int)
+        baddr = np.zeros((add_num, 32), dtype=int)
         tree_dict = {}
 
         # building address array

--- a/scripts/python/xml2vhdl-ox/xml2vhdl/xml2ic.py
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/xml2ic.py
@@ -410,7 +410,7 @@ def get_decoder_mask(address_list):
     add_num = len(addresses)
     logger.info('Addresses are: {}'
                 .format(add_num))
-    baddr = np.zeros((add_num, 32), dtype=np.int)
+    baddr = np.zeros((add_num, 32), dtype=int)
     decode_dict = {}
     tree_dict = {}
    


### PR DESCRIPTION
`np.int` is a deprecated alias for python builtin int. Now use builtin `int` type.