### PR TITLE
Removing the "U" mode when opening a file to be compatible with Python 3.11/3.12

### DIFF
--- a/scripts/python/xml2vhdl-ox/xml2vhdl/helper/string_io.py
+++ b/scripts/python/xml2vhdl-ox/xml2vhdl/helper/string_io.py
@@ -109,7 +109,7 @@ def file_list_generate(path_list, ext):
 
 # read template file
 def read_template_file(file_name):
-    template_file = open(file_name, "rU")
+    template_file = open(file_name, "r")
     text = template_file.read()
     text = normalize_template(text)
     template_file.close()


### PR DESCRIPTION
Universal line support was introduced in Python ~version 2.3. It was deprecated since Python 3.3 because open has a 'newline' option. The default newline option (None) is the same as the old 'U' option. The 'U' option was removed in Python 3.11.